### PR TITLE
Hotfix for mouse keys to get them working again on the Glove80 PR23

### DIFF
--- a/app/dts/behaviors/mouse_move.dtsi
+++ b/app/dts/behaviors/mouse_move.dtsi
@@ -1,8 +1,7 @@
 / {
     behaviors {
-        /omit-if-no-ref/ mmv: behavior_mouse_move {
+        /omit-if-no-ref/ mmv: mouse_move {
             compatible = "zmk,behavior-mouse-move";
-            label = "MOUSE_MOVE";
             #binding-cells = <1>;
             delay-ms = <0>;
             time-to-max-speed-ms = <300>;

--- a/app/dts/behaviors/mouse_scroll.dtsi
+++ b/app/dts/behaviors/mouse_scroll.dtsi
@@ -1,8 +1,7 @@
 / {
     behaviors {
-        /omit-if-no-ref/ msc: behavior_mouse_scroll {
+        /omit-if-no-ref/ msc: mouse_scroll {
             compatible = "zmk,behavior-mouse-scroll";
-            label = "MOUSE_SCROLL";
             #binding-cells = <1>;
             delay-ms = <0>;
             time-to-max-speed-ms = <300>;

--- a/app/src/behaviors/behavior_mouse_move.c
+++ b/app/src/behaviors/behavior_mouse_move.c
@@ -24,7 +24,7 @@ static int behavior_mouse_move_init(const struct device *dev) { return 0; };
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct mouse_config *config = dev->config;
     return raise_zmk_mouse_move_state_changed_from_encoded(binding->param1, *config, true,
                                                            event.timestamp);
@@ -33,7 +33,7 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct mouse_config *config = dev->config;
     return raise_zmk_mouse_move_state_changed_from_encoded(binding->param1, *config, false,
                                                            event.timestamp);
@@ -48,9 +48,9 @@ static const struct behavior_driver_api behavior_mouse_move_driver_api = {
         .time_to_max_speed_ms = DT_INST_PROP(n, time_to_max_speed_ms),                             \
         .acceleration_exponent = DT_INST_PROP(n, acceleration_exponent),                           \
     };                                                                                             \
-    DEVICE_DT_INST_DEFINE(n, behavior_mouse_move_init, NULL, NULL,                                 \
-                          &behavior_mouse_move_config_##n, POST_KERNEL,                            \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_mouse_move_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_mouse_move_init, NULL, NULL,                               \
+                            &behavior_mouse_move_config_##n, POST_KERNEL,                          \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_mouse_move_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KP_INST)
 

--- a/app/src/behaviors/behavior_mouse_scroll.c
+++ b/app/src/behaviors/behavior_mouse_scroll.c
@@ -25,7 +25,7 @@ static int behavior_mouse_scroll_init(const struct device *dev) { return 0; };
 static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
                                      struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct mouse_config *config = dev->config;
     return raise_zmk_mouse_scroll_state_changed_from_encoded(binding->param1, *config, true,
                                                              event.timestamp);
@@ -34,7 +34,7 @@ static int on_keymap_binding_pressed(struct zmk_behavior_binding *binding,
 static int on_keymap_binding_released(struct zmk_behavior_binding *binding,
                                       struct zmk_behavior_binding_event event) {
     LOG_DBG("position %d keycode 0x%02X", event.position, binding->param1);
-    const struct device *dev = device_get_binding(binding->behavior_dev);
+    const struct device *dev = zmk_behavior_get_binding(binding->behavior_dev);
     const struct mouse_config *config = dev->config;
     return raise_zmk_mouse_scroll_state_changed_from_encoded(binding->param1, *config, false,
                                                              event.timestamp);
@@ -49,9 +49,9 @@ static const struct behavior_driver_api behavior_mouse_scroll_driver_api = {
         .time_to_max_speed_ms = DT_INST_PROP(n, time_to_max_speed_ms),                             \
         .acceleration_exponent = DT_INST_PROP(n, acceleration_exponent),                           \
     };                                                                                             \
-    DEVICE_DT_INST_DEFINE(n, behavior_mouse_scroll_init, NULL, NULL,                               \
-                          &behavior_mouse_scroll_config_##n, POST_KERNEL,                          \
-                          CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_mouse_scroll_driver_api);
+    BEHAVIOR_DT_INST_DEFINE(                                                                       \
+        n, behavior_mouse_scroll_init, NULL, NULL, &behavior_mouse_scroll_config_##n, POST_KERNEL, \
+        CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &behavior_mouse_scroll_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(KP_INST)
 


### PR DESCRIPTION
Small hotfix to get mouse keys working again for the Glove80 [pull request 23](https://github.com/moergo-sc/zmk/pull/23). The new mouse behaviors mmv and msc in the PR are using the DEVICE_DT_INST_DEFINE macro to declare their driver.s But this doesn't add them to the list of behaviors. So `zmk_behavior_get_binding` in _keymap.c_ can't find them at runtime, leading to "No behavior assigned to %d on layer %d" errors when the keys are pressed. I changed their definition macros to BEHAVIOR_DT_INST_DEFINE to match the other behavior definitions and they seem to both work again.